### PR TITLE
Stop scraping politicians from term 2010

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -1,14 +1,7 @@
 require 'wikidata/fetcher'
 require 'pry'
 
-en_2010 = EveryPolitician::Wikidata.wikipedia_xpath( 
-  url: 'https://en.wikipedia.org/wiki/Chamber_of_Deputies_of_the_Dominican_Republic',
-  after: '//h2/span[@id="Composition_.282010.E2.80.932016.29"]',
-  before: '//h2/span[@id="Current_composition_.282016.E2.80.93_.29"]',
-  xpath: '//table//tr//td[1]//a[not(@class="new")]/@title',
-) 
-
-en_2016 = EveryPolitician::Wikidata.wikipedia_xpath( 
+en_2016 = EveryPolitician::Wikidata.wikipedia_xpath(
   url: 'https://en.wikipedia.org/wiki/Chamber_of_Deputies_of_the_Dominican_Republic',
   after: '//h2/span[@id="Current_composition_.282016.E2.80.93_.29"]',
   before: '//h2/span[@id="Party_strengths_in_the_Chamber_of_Deputies"]',
@@ -16,5 +9,5 @@ en_2016 = EveryPolitician::Wikidata.wikipedia_xpath(
 )
 
 es_names = WikiData::Category.new( 'Categoría:Políticos de República Dominicana', 'es').member_titles
-  
-EveryPolitician::Wikidata.scrape_wikidata(names: { en: en_2010 | en_2016, es: es_names }, output: false)
+
+EveryPolitician::Wikidata.scrape_wikidata(names: { en: en_2016, es: es_names }, output: false)


### PR DESCRIPTION
Morph was throwing the error

```
wikidata/fetcher.rb:41:in `wikipedia_xpath':
Can't find //h2/span[@id="Composition_.282010.E2.80.932016.29"] (RuntimeError)
    from scraper.rb:4:in `<main>'
```

the table with politicians from term 2010 was removed from that page
